### PR TITLE
auto-detection picks the wrong provider when the URL has a subdomain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,19 @@
-# 📝 Panduan Kontribusi
+// ...existing code...
+pub fn get_provider_name(url: &str) -> Result<String, String> {
+    let parsed_url = Url::parse(url).map_err(|e| e.to_string())?;
+    let domain = parsed_url.domain().ok_or("No domain found")?;
+    let parts: Vec<&str> = domain.split('.').collect();
+
+    // Heuristic: return the second-level domain when available (e.g. "www.pixeldrain.com" -> "pixeldrain")
+    let provider = if parts.len() >= 2 {
+        parts[parts.len() - 2]
+    } else {
+        parts[0]
+    };
+
+    Ok(provider.to_lowercase())
+}
+// ...existing code...# 📝 Panduan Kontribusi
 
 Terima kasih sudah tertarik untuk berkontribusi pada **Random Tools Collection**! 🎉 
 

--- a/tools/console/getdirecturl_cli-by-arsa/src/handler/auto.rs
+++ b/tools/console/getdirecturl_cli-by-arsa/src/handler/auto.rs
@@ -33,3 +33,18 @@ pub fn auto_handler(url: &str, download: bool) {
         Err(err) => eprintln!("❌ Gagal: {}", err),
     };
 }
+
+pub fn get_provider_name(url: &str) -> Result<String, String> {
+    let parsed_url = Url::parse(url).map_err(|e| e.to_string())?;
+    let domain = parsed_url.domain().ok_or("No domain found")?;
+    let parts: Vec<&str> = domain.split('.').collect();
+
+    // Heuristic: return the second-level domain when available (e.g. "www.pixeldrain.com" -> "pixeldrain")
+    let provider = if parts.len() >= 2 {
+        parts[parts.len() - 2]
+    } else {
+        parts[0]
+    };
+
+    Ok(provider.to_lowercase())
+}


### PR DESCRIPTION

Found a real bug: auto-detection picks the wrong provider when the URL has a subdomain 

